### PR TITLE
feat: Complete signal migration for Type, Appellation, and Region com…

### DIFF
--- a/client/src/app/appellation/appellation.page.html
+++ b/client/src/app/appellation/appellation.page.html
@@ -8,30 +8,28 @@
 </ion-header>
 
 <ion-content class="ion-padding">
-  @if (list) {
+  @if (list()) {
     <div>
-      @if (appellations$ | async) {
+      @if (appellations().length > 0) {
         <div>
           <ion-list>
-            @for (appellation of appellations$ | async; track appellation) {
+            @for (appellation of appellations(); track appellation._id) {
               <ion-item
                 (click)="editAppellation(appellation)"
                 >
                 {{ appellation.courte }} - {{appellation.longue}}
-                <!-- <ion-button slot="end" fill="outline">Modify -->
                 <ion-icon slot="end" color="dark" name="caret-forward-outline"></ion-icon>
-              <!-- </ion-button> -->
             </ion-item>
           }
         </ion-list>
       </div>
     }
-    <ion-button expand="full" (click)="editAppellation(appellation)">
+    <ion-button expand="full" (click)="editAppellation(null)">
       {{'general.add' | translate }} {{'appellation.appellation' | translate }}
     </ion-button>
   </div>
 }
-@if (!list) {
+@if (!list()) {
   <div>
     <form [formGroup]="appellationForm" id="appellation-form4">
       <ion-item id="appellation-input1">
@@ -42,11 +40,11 @@
           placeholder="{{ 'appellation.appellationShort' | translate }}"
           formControlName="courte"
           class="ion-text-right"
-          [class.invalid]="!appellationForm.controls.courte.valid && (appellationForm.controls.courte.dirty || submitted)"
+          [class.invalid]="!appellationForm.controls.courte.valid && (appellationForm.controls.courte.dirty || submitted())"
           >
         </ion-input>
       </ion-item>
-      @if (!appellationForm.controls.courte.valid  && (appellationForm.controls.courte.dirty || submitted)) {
+      @if (!appellationForm.controls.courte.valid  && (appellationForm.controls.courte.dirty || submitted())) {
         <ion-item
           >
           <p class="invalid">
@@ -62,7 +60,7 @@
           placeholder="{{ 'appellation.appellationLong' | translate }}"
           formControlName="longue"
           class="ion-text-right"
-          [class.invalid]="!appellationForm.controls.longue.valid && (appellationForm.controls.longue.dirty || submitted)"
+          [class.invalid]="!appellationForm.controls.longue.valid && (appellationForm.controls.longue.dirty || submitted())"
           >
         </ion-input>
       </ion-item>
@@ -86,31 +84,29 @@
         {{'general.cancel' | translate }}
       </ion-button>
     </form>
-    @if (!showWines) {
+    @if (!showWines()) {
       <ion-button
         color="secondary"
         fill="outline"
-        (click)="showWines = !showWines"
+        (click)="showWines.set(!showWines())"
         >
         {{'appellation.showWinesForAppellation' | translate }}
       </ion-button>
     }
-    @if (showWines) {
-      <ion-button color="secondary" fill="outline" (click)="showWines = !showWines">
+    @if (showWines()) {
+      <ion-button color="secondary" fill="outline" (click)="showWines.set(!showWines())">
         {{'appellation.hideWinesForAppellation' | translate }}
       </ion-button>
     }
-    @if (showWines && (winesForAppellation$ | async)) {
+    @if (showWines() && winesForAppellation().length > 0) {
       <div [ngClass]="'border'">
         <ion-list>
-          @for (wine of winesForAppellation$ | async; track wine) {
+          @for (wine of winesForAppellation(); track wine._id) {
             <ion-item
               [routerLink]="['/vin', wine._id]"
               >
               {{ wine.nom }} - {{wine.annee}} - {{wine.type.nom}}
-              <!-- <ion-button slot="end" fill="outline">Modify -->
               <ion-icon slot="end" color="dark" name="caret-forward-outline"></ion-icon>
-            <!-- </ion-button> -->
           </ion-item>
         }
       </ion-list>

--- a/client/src/app/appellation/appellation.page.ts
+++ b/client/src/app/appellation/appellation.page.ts
@@ -1,5 +1,6 @@
 import { TranslateService } from "@ngx-translate/core";
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, effect, signal, computed, inject, DestroyRef } from "@angular/core";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { NavController, AlertController, IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent, IonList, IonItem, IonIcon, IonButton, IonLabel, IonInput } from "@ionic/angular/standalone";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { AppellationModel, VinModel } from "../models/cellar.model";
@@ -12,12 +13,10 @@ import { RouterModule } from "@angular/router";
 
 import Debugger from "debug";
 import { Store } from "@ngrx/store";
-import * as AppellationSelectors from "../state/appellation/appellation.selectors";
 import * as VinSelectors from "../state/vin/vin.selectors";
 import * as AppellationActions from "../state/appellation/appellation.actions";
-import { Observable, Subject } from "rxjs";
-import { takeUntil, tap } from "rxjs/operators";
 import { AppState } from "../state/app.state";
+import { AppellationStore } from "../services/appellation-state.store";
 
 import { replacer } from "../util/util";
 import { addIcons } from "ionicons";
@@ -51,73 +50,82 @@ const debug = Debugger("app:appellation");
     ]
 })
 export class AppellationPage implements OnInit {
-    public appellation: AppellationModel = new AppellationModel({
+    // ============================================
+    // DEPENDENCIES (Inject)
+    // ============================================
+    private readonly route = inject(ActivatedRoute);
+    private readonly navCtrl = inject(NavController);
+    private readonly formBuilder = inject(FormBuilder);
+    private readonly translate = inject(TranslateService);
+    private readonly alertController = inject(AlertController);
+    private readonly toastCtrl = inject(ToastController);
+    private readonly store = inject(Store<AppState>);
+    private readonly appellationStore = inject(AppellationStore);
+    private readonly destroyRef = inject(DestroyRef);
+
+    // ============================================
+    // COMPONENT STATE (Signals)
+    // ============================================
+    // Current appellation being edited - as a signal
+    readonly currentAppellation = signal<AppellationModel>(new AppellationModel({
         _id: "",
         courte: "",
         longue: "",
-    });
-    public appellations$!: Observable<AppellationModel[]>;
-    private unsubscribe$ = new Subject<void>();
-    public winesForAppellation$!: Observable<VinModel[]>;
+    }));
 
-    public appellationList: Array<AppellationModel> = [];
-    public appellationsMap: Map<any, any> = new Map<any, any>();
-    public submitted: boolean = false;
+    // Get appellations list from AppellationStore
+    readonly appellations = this.appellationStore.appellationsList;
+    
+    // Get duplicate map from AppellationStore
+    readonly appellationsMap = this.appellationStore.appellationMapForDuplicates;
+
+    // Wines for this appellation - using a writable signal updated by effect
+    private readonly _winesForAppellation = signal<VinModel[]>([]);
+    readonly winesForAppellation = this._winesForAppellation.asReadonly();
+
+    public submitted = signal<boolean>(false);
     public appellationForm!: FormGroup;
-    public list: boolean = true;
-    public showWines: boolean = false;
+    public list = signal<boolean>(true);
+    public showWines = signal<boolean>(false);
 
-    constructor(
-        private route: ActivatedRoute,
-        private navCtrl: NavController,
-        private formBuilder: FormBuilder,
-        private translate: TranslateService,
-        private alertController: AlertController,
-        private toastCtrl: ToastController,
-        private store: Store<AppState>
-    ) {
-        addIcons({ caretForwardOutline });
-        addIcons({ caretForwardOutline });
-    }
+    // Route parameter as signal
+    private readonly routeParams = toSignal(this.route.params);
+    readonly appellationId = computed(() => this.routeParams()?.["id"] || null);
 
-    public ngOnInit() {
-        debug("[ngOnInit]called");
-        // form initialization
-        this.appellationForm = this.formBuilder.group(
-            {
-                courte: ["", Validators.required],
-                longue: ["", Validators.required],
-            },
-            { validator: this.noDouble.bind(this) }
-        );
-        this.submitted = false;
-        this.route.snapshot.data["action"] == "list"
-            ? (this.list = true)
-            : (this.list = false);
-        // We need to load the appellation list even if we create or modify an appellation because in this case we need the appellation list to check for doubles
-        this.appellations$ = this.store
-            .select(AppellationSelectors.getAllAppellationsArraySorted)
-            .pipe(takeUntil(this.unsubscribe$));
-        // loading appellations map from state (used for double check)
-        this.store
-            .select(AppellationSelectors.appellationMapForDuplicates)
-            .pipe(takeUntil(this.unsubscribe$))
-            .subscribe((appellationsMap) => (this.appellationsMap = appellationsMap));
-        // Now loading selected wine from the state
-        // if id param is there, the appellation will be loaded, if not, we want to create a new appellation and the form values will remain as initialized
-        this.store
-            .select(
-                AppellationSelectors.getAppellation(
-                    this.route.snapshot.paramMap.get("id")!
-                )
-            )
-            .pipe(takeUntil(this.unsubscribe$))
-            .subscribe((appellation) => {
+    constructor() {
+        addIcons({ caretForwardOutline });
+
+        // Effect: Load wines for the selected appellation
+        effect(() => {
+            const id = this.appellationId();
+            if (!id) {
+                this._winesForAppellation.set([]);
+                return;
+            }
+            
+            // Subscribe to wines for this appellation
+            this.store.select(VinSelectors.getWinesByAppellation(id))
+                .pipe(takeUntilDestroyed(this.destroyRef))
+                .subscribe(wines => {
+                    this._winesForAppellation.set(wines || []);
+                });
+        });
+
+        // Effect: Load selected appellation when appellationId changes
+        effect(() => {
+            const id = this.appellationId();
+            debug("[Effect:appellationId] Appellation ID changed:", id);
+
+            if (id) {
+                // Get appellation from store
+                const appellationSignal = this.appellationStore.getAppellationById(id);
+                const appellation = appellationSignal();
+                
                 if (appellation) {
-                    this.list = false;
-                    this.appellation = appellation;
-                    // We have selected an appellation
-                    // reset VinState status to avoid shadow UI messages coming from previous updates on other app instances
+                    this.list.set(false);
+                    this.currentAppellation.set(appellation);
+
+                    // Reset Appellation state to avoid shadow UI messages
                     this.store.dispatch(
                         AppellationActions.editAppellation({
                             id: appellation._id,
@@ -126,180 +134,165 @@ export class AppellationPage implements OnInit {
                     );
                     this.appellationForm.get("courte")!.setValue(appellation.courte);
                     this.appellationForm.get("longue")!.setValue(appellation.longue);
+                    debug("[ngOnInit]Appellation loaded : " + JSON.stringify(appellation));
+                }
+            } else {
+                // No appellation selected, creating new appellation
+                // Reset to empty appellation for new creation
+                this.currentAppellation.set(new AppellationModel({
+                    _id: "",
+                    courte: "",
+                    longue: "",
+                }));
+                this.store.dispatch(
+                    AppellationActions.editAppellation({ id: "", rev: "" })
+                );
+            }
+        }, { allowSignalWrites: true });
+
+        // Effect: Handle state changes from NgRx (for save/delete operations)
+        const appellationStateSignal = toSignal(this.store.select((state: AppState) => state.appellations));
+        effect(() => {
+            const appellationState = appellationStateSignal();
+            if (!appellationState) return;
+            
+            switch (appellationState.status) {
+                case "saved":
                     debug(
-                        "[Vin.ngOnInit]Appellation loaded : " + JSON.stringify(appellation)
+                        "[ngOnInit] handling change to 'saved' status - ts " +
+                        window.performance.now() +
+                        "\nappellationState : " +
+                        JSON.stringify(appellationState, replacer)
                     );
-                } else {
-                    // No wine was selected, when will register a new appellation
-                    this.store.dispatch(
-                        AppellationActions.editAppellation({ id: "", rev: "" })
-                    );
-                }
-            });
 
-        this.winesForAppellation$ = this.store
-            .select(VinSelectors.getWinesByAppellation(this.appellation._id))
-            .pipe(takeUntil(this.unsubscribe$));
-
-        // Handling state changes (originating from save, update or delete operations in the UI but also coming for synchronization with data from other application instances)
-        this.store
-            .select((state: AppState) => state.appellations)
-            .pipe(
-                takeUntil(this.unsubscribe$)
-                /*         tap((appellationState) =>
-                  debug(
-                    "[ngOnInit]handle appellationState Changes - ts " +
-                      window.performance.now() +
-                      "\nappellationState : " +
-                      JSON.stringify(appellationState, replacer)
-                  )
-                )
-         */
-            )
-            .subscribe((appellationState) => {
-                switch (appellationState.status) {
-                    case "saved":
-                        debug(
-                            "[ngOnInit] handling change to 'saved' status - ts " +
-                            window.performance.now() +
-                            "\nappellationState : " +
-                            JSON.stringify(appellationState, replacer)
-                        );
-
-                        // if we get an event that a wine is saved. We need to check it's id and
-                        // if the event source is internal (saved within this instance of the application) or external.
-                        // - (I) internal ? => (wine is saved in the application) a confirmation message is shown to the user and the app goes to the home scree
-                        // - (II) external ?
-                        //       - (A) event comes from the local DB resulting from the update of the wine we just saved
-                        //       - (B) event comes from the remoteDB resulting from the update of a wine ( not the one we are working on or having been working on)
-                        //       - (C) event coming from the remoteDB resulting from the update of the wine we are working on. (concurrent updata)
-                        if (appellationState.source == "internal") {
-                            debug("[ngInit](I) Standard wine saved");
-                            // Internal event
-                            this.presentToast(
-                                this.translate.instant("general.dataSaved"),
-                                "success",
-                                "home",
-                                2000
-                            );
-                            this.store.dispatch(AppellationActions.setStatusToLoaded());
-                        } else {
-                            // let's try to find a duplicate event in the eventLog
-                            let filteredEventLog = appellationState.eventLog.filter(
-                                (value) =>
-                                    value.id == appellationState.currentAppellation!.id &&
-                                    value.rev == appellationState.currentAppellation!.rev &&
-                                    value.action == "create"
-                            );
-                            debug(
-                                "[ngInit](II) FilteredEventLog : " +
-                                JSON.stringify(filteredEventLog)
-                            );
-                            if (filteredEventLog.length == 2) {
-                                debug(
-                                    "[ngInit](II.A) Duplicate state change for the same wine"
-                                );
-                                this.store.dispatch(AppellationActions.setStatusToLoaded());
-                            } else if (
-                                appellationState.eventLog[appellationState.eventLog.length - 1]
-                                    .id == appellationState.currentAppellation!.id &&
-                                appellationState.eventLog[appellationState.eventLog.length - 1]
-                                    .rev == appellationState.currentAppellation!.rev &&
-                                appellationState.eventLog[appellationState.eventLog.length - 1]
-                                    .action == "create" &&
-                                this.appellationForm.dirty // otherwize, there is no way to make the distinction when you open a brand new editing form for a wine that has been created in another application instance
-                            ) {
-                                // Event showing concurrent editing on the same wine that was saved somewhere else
-                                debug("[ngInit](II.C) Concurrent editing on the same wine");
-                                this.presentToast(
-                                    this.translate.instant(
-                                        "wine.savedConcurrentlyOnAnotherInstance"
-                                    ),
-                                    "warning",
-                                    "",
-                                    0,
-                                    "Close"
-                                );
-                            } else {
-                                debug("[ngInit](II.B) Update of another wine");
-                            }
-                        }
-                        break;
-                    case "error":
+                    if (appellationState.source == "internal") {
+                        debug("[ngInit](I) Standard appellation saved");
                         this.presentToast(
-                            this.translate.instant("general.DBError") +
-                            " " +
-                            appellationState.error,
-                            "error",
-                            null,
-                            5000
+                            this.translate.instant("general.dataSaved"),
+                            "success",
+                            "home",
+                            2000
                         );
-                        break;
-                    case "deleted":
-                        // if we get an event that an appellation is saved. We need to check it's id and
-                        // if the event source is internal (saved within this instance of the application) or external.
-                        // - (I) internal ? => (appellation is saved in the application) a confirmation message is shown to the user and the app goes to the home scree
-                        // - (II) external ?
-                        //       - (A) event comes from the local DB resulting from the update of the wine we just saved
-                        //       - (B) event comes from the remoteDB resulting from the update of a wine ( not the one we are working on or having been working on)
-                        //       - (C) event coming from the remoteDB resulting from the update of the wine we are working on. (concurrent updata)
-                        // Delete does not suppress a doc or it's revision. It just creates a new document (with a new revision) that has the "_delete" attribute set to true
-                        if (appellationState.source == "internal") {
-                            debug("[ngInit](I) Standard wine deleted");
-                            // Internal event
-                            this.presentToast(
-                                this.translate.instant("wine.wineDeleted"),
-                                "success",
-                                "home",
-                                2000
+                        this.store.dispatch(AppellationActions.setStatusToLoaded());
+                    } else {
+                        let filteredEventLog = appellationState.eventLog.filter(
+                            (value) =>
+                                value.id == appellationState.currentAppellation!.id &&
+                                value.rev == appellationState.currentAppellation!.rev &&
+                                value.action == "create"
+                        );
+                        debug(
+                            "[ngInit](II) FilteredEventLog : " +
+                            JSON.stringify(filteredEventLog)
+                        );
+                        
+                        if (filteredEventLog.length == 2) {
+                            debug(
+                                "[ngInit](II.A) Duplicate state change for the same appellation"
                             );
                             this.store.dispatch(AppellationActions.setStatusToLoaded());
+                        } else if (
+                            appellationState.eventLog[appellationState.eventLog.length - 1]
+                                .id == appellationState.currentAppellation!.id &&
+                            appellationState.eventLog[appellationState.eventLog.length - 1]
+                                .rev == appellationState.currentAppellation!.rev &&
+                            appellationState.eventLog[appellationState.eventLog.length - 1]
+                                .action == "create" &&
+                            this.appellationForm.dirty
+                        ) {
+                            debug("[ngInit](II.C) Concurrent editing on the same appellation");
+                            this.presentToast(
+                                this.translate.instant(
+                                    "wine.savedConcurrentlyOnAnotherInstance"
+                                ),
+                                "warning",
+                                "",
+                                0,
+                                "Close"
+                            );
                         } else {
-                            // let's try to find a duplicate event in the eventLog
-                            // this should never happen for a delete
-                            if (
-                                appellationState.eventLog.filter(
-                                    (value) =>
-                                        value.id == appellationState.currentAppellation!.id &&
-                                        value.rev >= appellationState.currentAppellation!.rev &&
-                                        value.action == "delete"
-                                ).length == 2
-                            ) {
-                                debug(
-                                    "[ngInit](II.A) Duplicate state change for the same wine"
-                                );
-                                this.store.dispatch(AppellationActions.setStatusToLoaded());
-                            } else if (
-                                appellationState.eventLog[appellationState.eventLog.length - 1]
-                                    .id == appellationState.currentAppellation!.id &&
-                                appellationState.eventLog[appellationState.eventLog.length - 1]
-                                    .action == "delete"
-                            ) {
-                                // Event showing concurrent editing on the same wine that was saved somewhere else
-                                debug("[ngInit](II.C) Concurrent editing on the same wine");
-                                this.presentToast(
-                                    this.translate.instant(
-                                        "wine.deletedConcurrentlyOnAnotherInstance"
-                                    ),
-                                    "warning",
-                                    "home",
-                                    0,
-                                    "Close"
-                                );
-                            } else {
-                                debug("[ngInit](II.B) Delete of another wine");
-                            }
+                            debug("[ngInit](II.B) Update of another appellation");
                         }
-                        break;
-                }
-            });
+                    }
+                    break;
+                    
+                case "error":
+                    this.presentToast(
+                        this.translate.instant("general.DBError") +
+                        " " +
+                        appellationState.error,
+                        "error",
+                        null,
+                        5000
+                    );
+                    break;
+                    
+                case "deleted":
+                    if (appellationState.source == "internal") {
+                        debug("[ngInit](I) Standard appellation deleted");
+                        this.presentToast(
+                            this.translate.instant("wine.wineDeleted"),
+                            "success",
+                            "home",
+                            2000
+                        );
+                        this.store.dispatch(AppellationActions.setStatusToLoaded());
+                    } else {
+                        const deleteEventsForCurrentAppellation = appellationState.eventLog.filter(
+                            (value) =>
+                                value.id == appellationState.currentAppellation!.id &&
+                                value.rev >= appellationState.currentAppellation!.rev &&
+                                value.action == "delete"
+                        );
+                        
+                        if (deleteEventsForCurrentAppellation.length >= 1) {
+                            // This is the external event following our internal delete
+                            debug(
+                                "[ngInit](II.A) Duplicate state change for the same appellation (external after internal)"
+                            );
+                            this.store.dispatch(AppellationActions.setStatusToLoaded());
+                        } else if (
+                            appellationState.eventLog[appellationState.eventLog.length - 1]
+                                .id == appellationState.currentAppellation!.id &&
+                            appellationState.eventLog[appellationState.eventLog.length - 1]
+                                .action == "delete"
+                        ) {
+                            debug("[ngInit](II.C) Concurrent editing on the same appellation");
+                            this.presentToast(
+                                this.translate.instant(
+                                    "wine.deletedConcurrentlyOnAnotherInstance"
+                                ),
+                                "warning",
+                                "home",
+                                0,
+                                "Close"
+                            );
+                        } else {
+                            debug("[ngInit](II.B) Delete of another appellation");
+                        }
+                    }
+                    break;
+            }
+        }, { allowSignalWrites: true });
     }
 
-    public ngOnDestroy() {
-        debug("[Appellation.ngOnDestroy]called");
-        // Unscubribe all observers
-        this.unsubscribe$.next();
-        this.unsubscribe$.complete();
+    public ngOnInit() {
+        debug("[ngOnInit]called");
+        
+        // form initialization
+        this.appellationForm = this.formBuilder.group(
+            {
+                courte: ["", Validators.required],
+                longue: ["", Validators.required],
+            },
+            { validator: this.noDouble.bind(this) }
+        );
+        this.submitted.set(false);
+        
+        // Set list mode based on route data
+        this.route.snapshot.data["action"] == "list"
+            ? this.list.set(true)
+            : this.list.set(false);
     }
 
     private noDouble(group: FormGroup) {
@@ -308,46 +301,44 @@ export class AppellationPage implements OnInit {
             !group.controls["courte"] ||
             !group.controls["longue"] ||
             !group.controls["courte"].dirty ||
-            !group.controls["courte"].dirty
+            !group.controls["longue"].dirty
         )
             return null;
-        /*     if (!group.controls.courte.dirty || !group.controls.courte.dirty)
-          return null;
-     */
+        
+        const appellationsMap = this.appellationsMap();
         if (
-            this.appellationsMap &&
-            this.appellationsMap.has(group.value.courte + group.value.longue)
+            appellationsMap &&
+            appellationsMap.has(group.value.courte + group.value.longue)
         ) {
             debug("[noDouble]double detected");
             return { double: true };
         } else return null;
     }
 
-    public editAppellation(appellation) {
-        if (appellation._id)
+    public editAppellation(appellation: AppellationModel | null) {
+        if (appellation && appellation._id)
             this.navCtrl.navigateForward(["/appellation", appellation._id]);
         else this.navCtrl.navigateForward(["/appellation"]);
     }
 
     public saveAppellation() {
         debug("[saveAppellation]entering");
-        this.submitted = true;
+        this.submitted.set(true);
+        
         if (this.appellationForm.valid) {
-            // validation succeeded
-            debug("[AppellationVin]Appellation valid");
-            // when the vin has been loaded from the store, it is immutable, we need to deep copy it before being able to update its properties
-            let mutableAppellation = JSON.parse(JSON.stringify(this.appellation));
-            // now combine the loaded wine data with the new form data
-            this.appellation = {
-                ...mutableAppellation,
+            debug("[saveAppellation]Appellation valid");
+            const currentAppellation = this.currentAppellation();
+            const updatedAppellation = {
+                ...currentAppellation,
                 ...this.appellationForm.value,
             };
+            this.currentAppellation.set(updatedAppellation);
 
             this.store.dispatch(
-                AppellationActions.createAppellation({ appellation: this.appellation })
+                AppellationActions.createAppellation({ appellation: updatedAppellation })
             );
         } else {
-            debug("[Vin - saveVin]vin invalid");
+            debug("[saveAppellation]appellation invalid");
             this.presentToast(
                 this.translate.instant("general.invalidData"),
                 "error",
@@ -357,12 +348,11 @@ export class AppellationPage implements OnInit {
     }
 
     public deleteAppellation() {
-        // Before deleting an appellation, we need to check if this appellation is not used for any of the wines.
-        // If it is used, it can't be deleted.
-        let used = false;
-        this.winesForAppellation$.subscribe((wineListForAppellation) =>
-            wineListForAppellation.length > 0 ? (used = true) : (used = false)
-        );
+        // Check if appellation is used by any wines
+        const currentAppellation = this.currentAppellation();
+        const wineList = this.winesForAppellation();
+        const used = wineList.length > 0;
+        
         if (!used) {
             this.alertController
                 .create({
@@ -377,7 +367,7 @@ export class AppellationPage implements OnInit {
                             handler: () => {
                                 this.store.dispatch(
                                     AppellationActions.deleteAppellation({
-                                        appellation: this.appellation,
+                                        appellation: currentAppellation,
                                     })
                                 );
                             },
@@ -439,3 +429,5 @@ export class AppellationPage implements OnInit {
         }
     }
 }
+
+// Made with Bob

--- a/client/src/app/home/home.page.html
+++ b/client/src/app/home/home.page.html
@@ -20,7 +20,7 @@
 
   @if(dashboardSelectedMaturity()!='') {
   <ion-list>
-    @for(wineToDrink of maturityWinesList(); track wineToDrink){
+    @for(wineToDrink of maturityWinesList(); track wineToDrink._id){
     <ion-item [routerLink]="['/vin', wineToDrink._id]" routerDirection="root" class="condensed">
       {{wineToDrink.nom}} ({{wineToDrink.annee}}) [{{wineToDrink.prixAchat}}€]@if (wineToDrink.type
       && wineToDrink.type.nom=='Rouge') {
@@ -86,7 +86,7 @@
   </ion-item>
 
   <ion-list>
-    @for(item of filteredWines(); track item){
+    @for(item of filteredWines(); track item._id){
     <ion-item [routerLink]="['/vin', item._id]" routerDirection="root">
       <ion-label>{{item.nom}} ({{item.annee}}) [{{item.prixAchat}}€]</ion-label>
       @if(item.type.nom=='Rouge'){

--- a/client/src/app/multi-level-side-menu/multi-level-side-menu.component.html
+++ b/client/src/app/multi-level-side-menu/multi-level-side-menu.component.html
@@ -1,5 +1,5 @@
 <ion-list class="ion-no-margin" no-lines>
-  @for (option of collapsableItems; track option; let i = $index) {
+  @for (option of collapsableItems; track option.id; let i = $index) {
     <!-- It is a simple option -->
     @if (!option.suboptionsCount) {
       <ion-item
@@ -69,7 +69,7 @@
           "
           class="options"
           >
-          @for (item of option.subOptions; track item) {
+          @for (item of option.subOptions; track item.id) {
             <ion-item
               class="sub-option"
               [style.padding-left]="subOptionIndentation + 'px'"

--- a/client/src/app/region/region.page.html
+++ b/client/src/app/region/region.page.html
@@ -8,34 +8,32 @@
 </ion-header>
 
 <ion-content class="ion-padding">
-  @if (list) {
+  @if (list()) {
     <div>
-      @if (origines$ | async) {
+      @if (origines().length > 0) {
         <div>
           <ion-list>
-            @for (origine of origines$ | async; track origine) {
+            @for (origine of origines(); track origine._id) {
               <ion-item
                 (click)="editOrigine(origine)"
                 >
                 {{ origine.pays }} - {{origine.region}}
-                <!-- <ion-button slot="end" fill="outline">Modify -->
                 <ion-icon
                   slot="end"
                   color="dark"
                   name="caret-forward-outline"
                 ></ion-icon>
-              <!-- </ion-button> -->
             </ion-item>
           }
         </ion-list>
       </div>
     }
-    <ion-button expand="full" (click)="editOrigine(origine)">
+    <ion-button expand="full" (click)="editOrigine(null)">
       {{'general.add' | translate }} {{'origin.region' | translate }}
     </ion-button>
   </div>
 }
-@if (!list) {
+@if (!list()) {
   <div>
     <form [formGroup]="origineForm" id="origine-form4">
       <ion-item id="origine-input1">
@@ -46,11 +44,11 @@
           placeholder="{{ 'origin.originCountry' | translate }}"
           formControlName="pays"
           class="ion-text-right"
-          [class.invalid]="!origineForm.controls.pays.valid && (origineForm.controls.pays.dirty || submitted)"
+          [class.invalid]="!origineForm.controls.pays.valid && (origineForm.controls.pays.dirty || submitted())"
           >
         </ion-input>
       </ion-item>
-      @if (!origineForm.controls.pays.valid  && (origineForm.controls.pays.dirty || submitted)) {
+      @if (!origineForm.controls.pays.valid  && (origineForm.controls.pays.dirty || submitted())) {
         <ion-item
           >
           <p class="invalid">
@@ -66,7 +64,7 @@
           placeholder="{{ 'origin.originRegion' | translate }}"
           formControlName="region"
           class="ion-text-right"
-          [class.invalid]="!origineForm.controls.region.valid && (origineForm.controls.region.dirty || submitted)"
+          [class.invalid]="!origineForm.controls.region.valid && (origineForm.controls.region.dirty || submitted())"
           >
         </ion-input>
       </ion-item>
@@ -85,11 +83,9 @@
         block
         (click)="saveOrigine()"
         >
-        <!--             <ion-button [disabled]="!origineForm.valid" id="region-button5" ion-button color="primary" block (click)="saveOrigine(origine)">
-        -->
         {{'general.save' | translate }}
       </ion-button>
-      @if (!newOrigine) {
+      @if (!newOrigine()) {
         <ion-button
           id="region-button5"
           ion-button
@@ -104,39 +100,37 @@
         {{'general.cancel' | translate }}
       </ion-button>
     </form>
-    @if (!showWines) {
+    @if (!showWines()) {
       <ion-button
         color="secondary"
         fill="outline"
-        (click)="showWines = !showWines"
+        (click)="showWines.set(!showWines())"
         >
         {{'origin.showWinesForOrigin' | translate }}
       </ion-button>
     }
-    @if (showWines) {
+    @if (showWines()) {
       <ion-button
         color="secondary"
         fill="outline"
-        (click)="showWines = !showWines"
+        (click)="showWines.set(!showWines())"
         >
         {{'origin.hideWinesForOrigin' | translate }}
       </ion-button>
     }
-    @if (showWines && (winesForOrigine$ | async)) {
+    @if (showWines() && winesForOrigine().length > 0) {
       <div [ngClass]="'border'">
         <ion-list>
-          @for (wine of winesForOrigine$ | async; track wine) {
+          @for (wine of winesForOrigine(); track wine._id) {
             <ion-item
               [routerLink]="['/vin', wine._id]"
               >
               {{ wine.nom }} - {{wine.annee}} - {{wine.type.nom}}
-              <!-- <ion-button slot="end" fill="outline">Modify -->
               <ion-icon
                 slot="end"
                 color="dark"
                 name="caret-forward-outline"
               ></ion-icon>
-            <!-- </ion-button> -->
           </ion-item>
         }
       </ion-list>

--- a/client/src/app/region/region.page.ts
+++ b/client/src/app/region/region.page.ts
@@ -1,6 +1,6 @@
 import { TranslateService } from "@ngx-translate/core";
-import { Component, OnInit, effect } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { Component, OnInit, effect, signal, computed, inject, DestroyRef } from "@angular/core";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { NavController, AlertController, IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent, IonList, IonItem, IonIcon, IonButton, IonLabel, IonInput } from "@ionic/angular/standalone";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { OrigineModel, VinModel } from "../models/cellar.model";
@@ -12,12 +12,10 @@ import { CommonModule } from "@angular/common";
 import { ReactiveFormsModule, FormsModule } from "@angular/forms";
 import { TranslateModule } from "@ngx-translate/core";
 import { RouterModule } from "@angular/router";
-import * as OrigineSelectors from "../state/origine/origine.selectors";
 import * as VinSelectors from "../state/vin/vin.selectors";
 import * as OrigineActions from "../state/origine/origine.actions";
-import { Observable, Subject } from "rxjs";
-import { flatMap, takeUntil, tap } from "rxjs/operators";
 import { AppState } from "../state/app.state";
+import { OrigineStore } from "../services/origine-state.store";
 
 import { replacer } from "../util/util";
 
@@ -47,94 +45,113 @@ const debug = Debugger("app:region");
     imports: [CommonModule, ReactiveFormsModule, FormsModule, TranslateModule, RouterModule, IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent, IonList, IonItem, IonIcon, IonButton, IonLabel, IonInput]
 })
 export class RegionPage implements OnInit {
-    public origine: OrigineModel = new OrigineModel({
+    // ============================================
+    // DEPENDENCIES (Inject)
+    // ============================================
+    private readonly route = inject(ActivatedRoute);
+    private readonly navCtrl = inject(NavController);
+    private readonly formBuilder = inject(FormBuilder);
+    private readonly translate = inject(TranslateService);
+    private readonly alertController = inject(AlertController);
+    private readonly toastCtrl = inject(ToastController);
+    private readonly store = inject(Store<AppState>);
+    private readonly origineStore = inject(OrigineStore);
+    private readonly destroyRef = inject(DestroyRef);
+
+    // ============================================
+    // COMPONENT STATE (Signals)
+    // ============================================
+    // Current origine being edited - as a signal
+    readonly currentOrigine = signal<OrigineModel>(new OrigineModel({
         _id: "",
         pays: "",
         region: "",
-    });
-    public origines$!: Observable<OrigineModel[]>;
-    private unsubscribe$ = new Subject<void>();
-    public winesForOrigine$!: Observable<VinModel[]>;
+    }));
 
-    public origineList: Array<OrigineModel> = [];
-    public originesMap: Map<any, any> = new Map<any, any>();
-    public submitted: boolean = false;
+    // Get origines list from OrigineStore
+    readonly origines = this.origineStore.originesList;
+    
+    // Get duplicate map from OrigineStore
+    readonly originesMap = this.origineStore.origineMapForDuplicates;
+
+    // Wines for this origine - using a writable signal updated by effect
+    private readonly _winesForOrigine = signal<VinModel[]>([]);
+    readonly winesForOrigine = this._winesForOrigine.asReadonly();
+
+    public submitted = signal<boolean>(false);
     public origineForm!: FormGroup;
-    public list: boolean = true;
-    public showWines: boolean = false;
-    public newOrigine: boolean = false;
+    public list = signal<boolean>(true);
+    public showWines = signal<boolean>(false);
+    public newOrigine = signal<boolean>(false);
 
-    constructor(
-        private route: ActivatedRoute,
-        private navCtrl: NavController,
-        private formBuilder: FormBuilder,
-        private translate: TranslateService,
-        private alertController: AlertController,
-        private toastCtrl: ToastController,
-        private store: Store<AppState>
-    ) {
-        addIcons({ caretForwardOutline });
-        addIcons({ caretForwardOutline });
-    }
+    // Route parameter as signal
+    private readonly routeParams = toSignal(this.route.params);
+    readonly origineId = computed(() => this.routeParams()?.["id"] || null);
 
-    public ngOnInit() {
-        debug("[ngOnInit]called");
-        // form initialization
-        this.origineForm = this.formBuilder.group(
-            {
-                pays: ["", Validators.required],
-                region: ["", Validators.required],
-            },
-            { validator: this.noDouble.bind(this) }
-        );
-        this.submitted = false;
-        this.route.snapshot.data["action"] == "list"
-            ? (this.list = true)
-            : (this.list = false);
-        // We need to load the origine list even if we create or modify an origine because in this case we need the origine list to check for doubles
-        this.origines$ = this.store.select(OrigineSelectors.getAllOriginesArraySorted);
-        // loading origines map from state (used for double check) via signal
-        const originesMapSignal = toSignal(this.store.select(OrigineSelectors.origineMapForDuplicates));
+    constructor() {
+        addIcons({ caretForwardOutline });
+
+        // Effect: Load wines for the selected origine
         effect(() => {
-            this.originesMap = originesMapSignal() ?? new Map<any, any>(); // Guarded assignment
+            const id = this.origineId();
+            if (!id) {
+                this._winesForOrigine.set([]);
+                return;
+            }
+            
+            // Subscribe to wines for this origine
+            this.store.select(VinSelectors.getWinesByOrigine(id))
+                .pipe(takeUntilDestroyed(this.destroyRef))
+                .subscribe(wines => {
+                    this._winesForOrigine.set(wines || []);
+                });
         });
-        // Now loading selected wine from the state
-        // if id param is there, the origine will be loaded, if not, we want to create a new origine and the form values will remain as initialized
-        const selectedOrigineSignal = toSignal(
-            this.store.select(OrigineSelectors.getOrigine(this.route.snapshot.paramMap.get("id")!))
-        );
-        effect(() => {
-            const origine = selectedOrigineSignal();
-            if (origine) {
-                this.list = false;
-                this.origine = origine;
-                this.newOrigine = false;
-                // We have selected an origine
-                // reset VinState status to avoid shadow UI messages coming from previous updates on other app instances
 
-                this.store.dispatch(
-                    OrigineActions.editOrigine({
-                        id: origine._id!,
-                        rev: origine._rev!,
-                    })
-                );
-                this.origineForm.get("pays")!.setValue(origine.pays);
-                this.origineForm.get("region")!.setValue(origine.region);
-                debug("[Vin.ngOnInit]Origine loaded : " + JSON.stringify(origine));
+        // Effect: Load selected origine when origineId changes
+        effect(() => {
+            const id = this.origineId();
+            debug("[Effect:origineId] Origine ID changed:", id);
+
+            if (id) {
+                // Get origine from store
+                const origineSignal = this.origineStore.getOrigineById(id);
+                const origine = origineSignal();
+                
+                if (origine) {
+                    this.list.set(false);
+                    this.currentOrigine.set(origine);
+                    this.newOrigine.set(false);
+                    
+                    // Reset Origine state to avoid shadow UI messages
+                    this.store.dispatch(
+                        OrigineActions.editOrigine({
+                            id: origine._id!,
+                            rev: origine._rev!,
+                        })
+                    );
+                    this.origineForm.get("pays")!.setValue(origine.pays);
+                    this.origineForm.get("region")!.setValue(origine.region);
+                    debug("[ngOnInit]Origine loaded : " + JSON.stringify(origine));
+                }
             } else {
-                // No wine was selected, when will register a new origine
-                this.newOrigine = true;
+                // No origine selected, creating new origine
+                this.newOrigine.set(true);
+                // Reset to empty origine for new creation
+                this.currentOrigine.set(new OrigineModel({
+                    _id: "",
+                    pays: "",
+                    region: "",
+                }));
                 this.store.dispatch(OrigineActions.editOrigine({ id: "", rev: "" }));
             }
-        });
+        }, { allowSignalWrites: true });
 
-        this.winesForOrigine$ = this.store.select(VinSelectors.getWinesByOrigine(this.origine._id));
-
-        // Handling state changes (originating from save, update or delete operations in the UI but also coming for synchronization with data from other application instances)
+        // Effect: Handle state changes from NgRx (for save/delete operations)
         const origineStateSignal = toSignal(this.store.select((state: AppState) => state.origines));
         effect(() => {
             const origineState = origineStateSignal();
-            if (!origineState) return; // guard against undefined
+            if (!origineState) return;
+            
             switch (origineState.status) {
                 case "saved":
                     debug(
@@ -144,16 +161,8 @@ export class RegionPage implements OnInit {
                         JSON.stringify(origineState, replacer)
                     );
 
-                    // if we get an event that a wine is saved. We need to check it's id and
-                    // if the event source is internal (saved within this instance of the application) or external.
-                    // - (I) internal ? => (wine is saved in the application) a confirmation message is shown to the user and the app goes to the home scree
-                    // - (II) external ?
-                    //       - (A) event comes from the local DB resulting from the update of the wine we just saved
-                    //       - (B) event comes from the remoteDB resulting from the update of a wine ( not the one we are working on or having been working on)
-                    //       - (C) event coming from the remoteDB resulting from the update of the wine we are working on. (concurrent updata)
                     if (origineState.source == "internal") {
-                        debug("[ngInit](I) Standard wine saved");
-                        // Internal event
+                        debug("[ngInit](I) Standard origine saved");
                         this.presentToast(
                             this.translate.instant("general.dataSaved"),
                             "success",
@@ -162,7 +171,6 @@ export class RegionPage implements OnInit {
                         );
                         this.store.dispatch(OrigineActions.setStatusToLoaded());
                     } else {
-                        // let's try to find a duplicate event in the eventLog
                         let filteredEventLog = origineState.eventLog.filter(
                             (value) =>
                                 value.id == origineState.currentOrigine!.id &&
@@ -170,8 +178,9 @@ export class RegionPage implements OnInit {
                                 value.action == "create"
                         );
                         debug("[ngInit](II) FilteredEventLog : " + JSON.stringify(filteredEventLog));
+                        
                         if (filteredEventLog.length == 2) {
-                            debug("[ngInit](II.A) Duplicate state change for the same wine");
+                            debug("[ngInit](II.A) Duplicate state change for the same origine");
                             this.store.dispatch(OrigineActions.setStatusToLoaded());
                         } else if (
                             origineState.eventLog[origineState.eventLog.length - 1].id ==
@@ -180,10 +189,9 @@ export class RegionPage implements OnInit {
                             origineState.currentOrigine!.rev &&
                             origineState.eventLog[origineState.eventLog.length - 1].action ==
                             "create" &&
-                            this.origineForm.dirty // otherwize, there is no way to make the distinction when you open a brand new editing form for a wine that has been created in another application instance
+                            this.origineForm.dirty
                         ) {
-                            // Event showing concurrent editing on the same wine that was saved somewhere else
-                            debug("[ngInit](II.C) Concurrent editing on the same wine");
+                            debug("[ngInit](II.C) Concurrent editing on the same origine");
                             this.presentToast(
                                 this.translate.instant("wine.savedConcurrentlyOnAnotherInstance"),
                                 "warning",
@@ -192,10 +200,11 @@ export class RegionPage implements OnInit {
                                 "Close"
                             );
                         } else {
-                            debug("[ngInit](II.B) Update of another wine");
+                            debug("[ngInit](II.B) Update of another origine");
                         }
                     }
                     break;
+                    
                 case "error":
                     this.presentToast(
                         this.translate.instant("general.DBError") + " " + origineState.error,
@@ -204,18 +213,10 @@ export class RegionPage implements OnInit {
                         5000
                     );
                     break;
+                    
                 case "deleted":
-                    // if we get an event that an origine is saved. We need to check it's id and
-                    // if the event source is internal (saved within this instance of the application) or external.
-                    // - (I) internal ? => (origine is saved in the application) a confirmation message is shown to the user and the app goes to the home scree
-                    // - (II) external ?
-                    //       - (A) event comes from the local DB resulting from the update of the wine we just saved
-                    //       - (B) event comes from the remoteDB resulting from the update of a wine ( not the one we are working on or having been working on)
-                    //       - (C) event coming from the remoteDB resulting from the update of the wine we are working on. (concurrent updata)
-                    // Delete does not suppress a doc or it's revision. It just creates a new document (with a new revision) that has the "_delete" attribute set to true
                     if (origineState.source == "internal") {
-                        debug("[ngInit](I) Standard wine deleted");
-                        // Internal event
+                        debug("[ngInit](I) Standard origine deleted");
                         this.presentToast(
                             this.translate.instant("wine.wineDeleted"),
                             "success",
@@ -224,17 +225,16 @@ export class RegionPage implements OnInit {
                         );
                         this.store.dispatch(OrigineActions.setStatusToLoaded());
                     } else {
-                        // let's try to find a duplicate event in the eventLog
-                        // this should never happen for a delete
-                        if (
-                            origineState.eventLog.filter(
-                                (value) =>
-                                    value.id == origineState.currentOrigine!.id &&
-                                    value.rev >= origineState.currentOrigine!.rev &&
-                                    value.action == "delete"
-                            ).length == 2
-                        ) {
-                            debug("[ngInit](II.A) Duplicate state change for the same wine");
+                        const deleteEventsForCurrentOrigine = origineState.eventLog.filter(
+                            (value) =>
+                                value.id == origineState.currentOrigine!.id &&
+                                value.rev >= origineState.currentOrigine!.rev &&
+                                value.action == "delete"
+                        );
+                        
+                        if (deleteEventsForCurrentOrigine.length >= 1) {
+                            // This is the external event following our internal delete
+                            debug("[ngInit](II.A) Duplicate state change for the same origine (external after internal)");
                             this.store.dispatch(OrigineActions.setStatusToLoaded());
                         } else if (
                             origineState.eventLog[origineState.eventLog.length - 1].id ==
@@ -242,7 +242,7 @@ export class RegionPage implements OnInit {
                             origineState.eventLog[origineState.eventLog.length - 1].action ==
                             "delete"
                         ) {
-                            debug("[ngInit](II.C) Concurrent editing on the same wine");
+                            debug("[ngInit](II.C) Concurrent editing on the same origine");
                             this.presentToast(
                                 this.translate.instant("wine.deletedConcurrentlyOnAnotherInstance"),
                                 "warning",
@@ -251,19 +251,31 @@ export class RegionPage implements OnInit {
                                 "Close"
                             );
                         } else {
-                            debug("[ngInit](II.B) Delete of another wine");
+                            debug("[ngInit](II.B) Delete of another origine");
                         }
                     }
                     break;
             }
-        });
+        }, { allowSignalWrites: true });
     }
 
-    public ngOnDestroy() {
-        debug("[Origine.ngOnDestroy]called");
-        // Unscubribe all observers
-        this.unsubscribe$.next();
-        this.unsubscribe$.complete();
+    public ngOnInit() {
+        debug("[ngOnInit]called");
+        
+        // form initialization
+        this.origineForm = this.formBuilder.group(
+            {
+                pays: ["", Validators.required],
+                region: ["", Validators.required],
+            },
+            { validator: this.noDouble.bind(this) }
+        );
+        this.submitted.set(false);
+        
+        // Set list mode based on route data
+        this.route.snapshot.data["action"] == "list"
+            ? this.list.set(true)
+            : this.list.set(false);
     }
 
     private noDouble(group: FormGroup) {
@@ -275,39 +287,40 @@ export class RegionPage implements OnInit {
             !group.controls["region"].dirty
         )
             return null;
+        
+        const originesMap = this.originesMap();
         if (
-            this.originesMap &&
-            this.originesMap.has(group.value.pays + group.value.region)
+            originesMap &&
+            originesMap.has(group.value.pays + group.value.region)
         ) {
             debug("[noDouble]double detected");
             return { double: true };
         } else return null;
     }
 
-    public editOrigine(origine) {
-        if (origine._id) this.navCtrl.navigateForward(["/region", origine._id]);
+    public editOrigine(origine: OrigineModel | null) {
+        if (origine && origine._id) this.navCtrl.navigateForward(["/region", origine._id]);
         else this.navCtrl.navigateForward(["/region"]);
     }
 
     public saveOrigine() {
         debug("[saveOrigine]entering");
-        this.submitted = true;
+        this.submitted.set(true);
+        
         if (this.origineForm.valid) {
-            // validation succeeded
-            debug("[OrigineVin]Origine valid");
-            // when the vin has been loaded from the store, it is immutable, we need to deep copy it before being able to update its properties
-            let mutableOrigine = JSON.parse(JSON.stringify(this.origine));
-            // now combine the loaded wine data with the new form data
-            this.origine = {
-                ...mutableOrigine,
+            debug("[saveOrigine]Origine valid");
+            const currentOrigine = this.currentOrigine();
+            const updatedOrigine = {
+                ...currentOrigine,
                 ...this.origineForm.value,
             };
+            this.currentOrigine.set(updatedOrigine);
 
             this.store.dispatch(
-                OrigineActions.createOrigine({ origine: this.origine })
+                OrigineActions.createOrigine({ origine: updatedOrigine })
             );
         } else {
-            debug("[Vin - saveVin]vin invalid");
+            debug("[saveOrigine]origine invalid");
             this.presentToast(
                 this.translate.instant("general.invalidData"),
                 "error",
@@ -317,12 +330,11 @@ export class RegionPage implements OnInit {
     }
 
     public deleteOrigine() {
-        // Before deleting an origine, we need to check if this origine is not used for any of the wines.
-        // If it is used, it can't be deleted.
-        let used = false;
-        // read once from the wines observable without subscribing permanently
-        const wineListForOrigine = toSignal(this.store.select(VinSelectors.getWinesByOrigine(this.origine._id)))();
-        if (wineListForOrigine) used = wineListForOrigine.length > 0;
+        // Check if origine is used by any wines
+        const currentOrigine = this.currentOrigine();
+        const wineList = this.winesForOrigine();
+        const used = wineList.length > 0;
+        
         if (!used) {
             this.alertController
                 .create({
@@ -337,7 +349,7 @@ export class RegionPage implements OnInit {
                             handler: () => {
                                 this.store.dispatch(
                                     OrigineActions.deleteOrigine({
-                                        origine: this.origine,
+                                        origine: currentOrigine,
                                     })
                                 );
                             },
@@ -399,3 +411,5 @@ export class RegionPage implements OnInit {
         }
     }
 }
+
+// Made with Bob

--- a/client/src/app/services/appellation-state.store.ts
+++ b/client/src/app/services/appellation-state.store.ts
@@ -1,0 +1,129 @@
+import { computed, inject, DestroyRef } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withHooks,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Store } from '@ngrx/store';
+import { AppellationModel } from '../models/cellar.model';
+import { AppState } from '../state/app.state';
+import * as AppellationSelectors from '../state/appellation/appellation.selectors';
+import Debugger from 'debug';
+
+const debug = Debugger('app:appellation-store');
+
+// ============================================
+// STATE INTERFACE
+// ============================================
+interface AppellationStoreState {
+  appellations: Map<string, AppellationModel>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+// ============================================
+// INITIAL STATE
+// ============================================
+const initialState: AppellationStoreState = {
+  appellations: new Map<string, AppellationModel>(),
+  isLoading: false,
+  error: null,
+};
+
+// ============================================
+// APPELLATION STORE
+// ============================================
+export const AppellationStore = signalStore(
+  { providedIn: 'root' },
+  withState(initialState),
+
+  // ============================================
+  // COMPUTED SIGNALS
+  // ============================================
+  withComputed((store) => ({
+    // Sorted list of all appellations (by courte + longue)
+    appellationsList: computed(() => {
+      const appellationsMap = store.appellations();
+      return Array.from(appellationsMap.values()).sort((a, b) => {
+        const aKey = (a.courte || '') + (a.longue || '');
+        const bKey = (b.courte || '') + (b.longue || '');
+        return aKey.localeCompare(bKey);
+      });
+    }),
+
+    // Map for duplicate detection (key: courte + longue)
+    appellationMapForDuplicates: computed(() => {
+      const appellationsMap = store.appellations();
+      const duplicateMap = new Map<string, AppellationModel>();
+      appellationsMap.forEach((appellation) => {
+        const key = (appellation.courte || '') + (appellation.longue || '');
+        duplicateMap.set(key, appellation);
+      });
+      return duplicateMap;
+    }),
+  })),
+
+  // ============================================
+  // METHODS
+  // ============================================
+  withMethods((store, ngrxStore = inject(Store<AppState>), destroyRef = inject(DestroyRef)) => {
+    // Local function to get a specific appellation by ID
+    const getAppellationById = (id: string) =>
+      computed(() => {
+        const appellationsMap = store.appellations();
+        return appellationsMap.get(id);
+      });
+
+    return {
+      // Get a specific appellation by ID (returns computed signal)
+      getAppellationById,
+
+      // Load appellations from NgRx store (keeps subscription alive for updates)
+      loadAppellations: () => {
+        debug('[loadAppellations] Loading appellations and subscribing to updates');
+        patchState(store, { isLoading: true });
+        
+        // Subscribe to NgRx store and keep subscription alive for continuous updates
+        ngrxStore.select(AppellationSelectors.getAllAppellations)
+          .pipe(takeUntilDestroyed(destroyRef))
+          .subscribe({
+            next: (appellationsMap) => {
+              debug('[loadAppellations] Received appellations update:', appellationsMap.size);
+              patchState(store, {
+                appellations: new Map(appellationsMap),
+                isLoading: false,
+                error: null,
+              });
+            },
+            error: (error) => {
+              debug('[loadAppellations] Error:', error);
+              patchState(store, {
+                isLoading: false,
+                error: error.message || 'Failed to load appellations',
+              });
+            },
+          });
+      },
+    };
+  }),
+
+  // ============================================
+  // LIFECYCLE HOOKS
+  // ============================================
+  withHooks({
+    onInit(store) {
+      debug('[AppellationStore] Initializing');
+      // Auto-load appellations on initialization
+      store.loadAppellations();
+    },
+    onDestroy() {
+      debug('[AppellationStore] Destroying');
+    },
+  })
+);
+
+// Made with Bob

--- a/client/src/app/services/origine-state.store.ts
+++ b/client/src/app/services/origine-state.store.ts
@@ -1,0 +1,141 @@
+import { computed, inject, DestroyRef } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withHooks,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Store } from '@ngrx/store';
+import { OrigineModel } from '../models/cellar.model';
+import { AppState } from '../state/app.state';
+import * as OrigineSelectors from '../state/origine/origine.selectors';
+import Debugger from 'debug';
+
+const debug = Debugger('app:origine-store');
+
+// ============================================
+// STATE INTERFACE
+// ============================================
+interface OrigineStoreState {
+  origines: Map<string, OrigineModel>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+// ============================================
+// INITIAL STATE
+// ============================================
+const initialState: OrigineStoreState = {
+  origines: new Map<string, OrigineModel>(),
+  isLoading: false,
+  error: null,
+};
+
+// ============================================
+// ORIGINE STORE
+// ============================================
+export const OrigineStore = signalStore(
+  { providedIn: 'root' },
+  withState(initialState),
+
+  // ============================================
+  // COMPUTED SIGNALS
+  // ============================================
+  withComputed((store) => ({
+    // Sorted list of all origines (by pays + region)
+    originesList: computed(() => {
+      const originesMap = store.origines();
+      return Array.from(originesMap.values()).sort((a, b) => {
+        const aKey = (a.pays || '') + (a.region || '');
+        const bKey = (b.pays || '') + (b.region || '');
+        return aKey.localeCompare(bKey);
+      });
+    }),
+
+    // Map for duplicate detection (key: pays + region)
+    origineMapForDuplicates: computed(() => {
+      const originesMap = store.origines();
+      const duplicateMap = new Map<string, OrigineModel>();
+      originesMap.forEach((origine) => {
+        const key = (origine.pays || '') + (origine.region || '');
+        duplicateMap.set(key, origine);
+      });
+      return duplicateMap;
+    }),
+  })),
+
+  // ============================================
+  // METHODS
+  // ============================================
+  withMethods((store, ngrxStore = inject(Store<AppState>), destroyRef = inject(DestroyRef)) => {
+    // Local function to get a specific origine by ID
+    const getOrigineById = (id: string) =>
+      computed(() => {
+        const originesMap = store.origines();
+        return originesMap.get(id);
+      });
+
+    return {
+      // Get a specific origine by ID (returns computed signal)
+      getOrigineById,
+
+      // Load origines from NgRx store (keeps subscription alive for updates)
+      loadOrigines: () => {
+        debug('[loadOrigines] Loading origines and subscribing to updates');
+        patchState(store, { isLoading: true });
+        
+        // Subscribe to NgRx store and keep subscription alive for continuous updates
+        ngrxStore.select(OrigineSelectors.getAllOrigines)
+          .pipe(takeUntilDestroyed(destroyRef))
+          .subscribe({
+            next: (originesMap) => {
+              debug('[loadOrigines] Received origines update. Size:', originesMap.size);
+              
+              // Filter out any non-origine documents and create new Map
+              const newMap = new Map<string, OrigineModel>();
+              originesMap.forEach((value, key) => {
+                // Only add if it's a valid origine document
+                if (key && key.startsWith('origine|') && value && value._id) {
+                  newMap.set(key, value);
+                } else {
+                  debug('[loadOrigines] Filtered out invalid entry:', { key, value });
+                }
+              });
+              
+              patchState(store, {
+                origines: newMap,
+                isLoading: false,
+                error: null,
+              });
+            },
+            error: (error) => {
+              debug('[loadOrigines] Error:', error);
+              patchState(store, {
+                isLoading: false,
+                error: error.message || 'Failed to load origines',
+              });
+            },
+          });
+      },
+    };
+  }),
+
+  // ============================================
+  // LIFECYCLE HOOKS
+  // ============================================
+  withHooks({
+    onInit(store) {
+      debug('[OrigineStore] Initializing');
+      // Auto-load origines on initialization
+      store.loadOrigines();
+    },
+    onDestroy() {
+      debug('[OrigineStore] Destroying');
+    },
+  })
+);
+
+// Made with Bob

--- a/client/src/app/services/type-state.store.ts
+++ b/client/src/app/services/type-state.store.ts
@@ -1,0 +1,128 @@
+import { computed, inject, DestroyRef } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withHooks,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Store } from '@ngrx/store';
+import { TypeModel } from '../models/cellar.model';
+import { AppState } from '../state/app.state';
+import * as TypeSelectors from '../state/type/type.selectors';
+import Debugger from 'debug';
+
+const debug = Debugger('app:type-store');
+
+// ============================================
+// STATE INTERFACE
+// ============================================
+interface TypeStoreState {
+  types: Map<string, TypeModel>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+// ============================================
+// INITIAL STATE
+// ============================================
+const initialState: TypeStoreState = {
+  types: new Map<string, TypeModel>(),
+  isLoading: false,
+  error: null,
+};
+
+// ============================================
+// TYPE STORE
+// ============================================
+export const TypeStore = signalStore(
+  { providedIn: 'root' },
+  withState(initialState),
+
+  // ============================================
+  // COMPUTED SIGNALS
+  // ============================================
+  withComputed((store) => ({
+    // Sorted list of all types
+    typesList: computed(() => {
+      const typesMap = store.types();
+      return Array.from(typesMap.values()).sort((a, b) =>
+        (a.nom || '').localeCompare(b.nom || '')
+      );
+    }),
+
+    // Map for duplicate detection (key: nom)
+    typeMapForDuplicates: computed(() => {
+      const typesMap = store.types();
+      const duplicateMap = new Map<string, TypeModel>();
+      typesMap.forEach((type) => {
+        if (type.nom) {
+          duplicateMap.set(type.nom, type);
+        }
+      });
+      return duplicateMap;
+    }),
+  })),
+
+  // ============================================
+  // METHODS
+  // ============================================
+  withMethods((store, ngrxStore = inject(Store<AppState>), destroyRef = inject(DestroyRef)) => {
+    // Local function to get a specific type by ID
+    const getTypeById = (id: string) =>
+      computed(() => {
+        const typesMap = store.types();
+        return typesMap.get(id);
+      });
+
+    return {
+      // Get a specific type by ID (returns computed signal)
+      getTypeById,
+
+      // Load types from NgRx store (keeps subscription alive for updates)
+      loadTypes: () => {
+        debug('[loadTypes] Loading types and subscribing to updates');
+        patchState(store, { isLoading: true });
+        
+        // Subscribe to NgRx store and keep subscription alive for continuous updates
+        ngrxStore.select(TypeSelectors.getAllTypes)
+          .pipe(takeUntilDestroyed(destroyRef))
+          .subscribe({
+            next: (typesMap) => {
+              debug('[loadTypes] Received types update:', typesMap.size);
+              patchState(store, {
+                types: new Map(typesMap),
+                isLoading: false,
+                error: null,
+              });
+            },
+            error: (error) => {
+              debug('[loadTypes] Error:', error);
+              patchState(store, {
+                isLoading: false,
+                error: error.message || 'Failed to load types',
+              });
+            },
+          });
+      },
+    };
+  }),
+
+  // ============================================
+  // LIFECYCLE HOOKS
+  // ============================================
+  withHooks({
+    onInit(store) {
+      debug('[TypeStore] Initializing');
+      // Auto-load types on initialization
+      store.loadTypes();
+    },
+    onDestroy() {
+      debug('[TypeStore] Destroying');
+    },
+  })
+);
+
+// Made with Bob

--- a/client/src/app/state/appellation/appellation.effects.ts
+++ b/client/src/app/state/appellation/appellation.effects.ts
@@ -54,14 +54,15 @@ export class AppellationEffects {
       this.actions$.pipe(
         ofType(AppellationAction.createAppellation),
         switchMap((action) => {
-          //        this.lastSavedWine = action.appellation;
-          return of(
+          // Convert Promise to Observable using from()
+          return from(
             this.pouchService.saveDoc(
               Object.assign({}, action.appellation),
               "appellation"
-            )
+            ) as Promise<IResult>
           ).pipe(
             map((result: IResult) => {
+              debug("[saveAppellation$] Save result:", result);
               return AppellationAction.createAppellationSuccess({
                 appellation: {
                   ...action.appellation,
@@ -71,9 +72,10 @@ export class AppellationEffects {
                 source: "internal",
               });
             }),
-            catchError((error) =>
-              of(AppellationAction.createAppellationFailure({ error }))
-            )
+            catchError((error) => {
+              debug("[saveAppellation$] Save error:", error);
+              return of(AppellationAction.createAppellationFailure({ error }));
+            })
           );
         })
         /*        exhaustMap((action) =>
@@ -125,25 +127,35 @@ export class AppellationEffects {
   handleChanges$ = createEffect(
     () =>
       this.pouchService.dbChanges$.pipe(
+        // Filter to only process appellation documents
         tap((change) =>
           debug(
             "[handleChanges Effect]ts: " +
               window.performance.now() +
               "\n - change : " +
-              JSON.stringify(change)
+              JSON.stringify(change) +
+              "\n - doc._id: " +
+              change.doc?._id
           )
         ),
+        // Only process changes for appellation documents (those with _id starting with "appellation|")
         map((change) => {
-          if (!change.deleted) {
-            return AppellationAction.createAppellationSuccess({
-              appellation: change.doc,
-              source: "external",
-            });
-          } else
-            return AppellationAction.deleteAppellationSuccess({
-              result: change,
-              source: "external",
-            });
+          // Check if this is an appellation document
+          if (change.doc && change.doc._id && change.doc._id.startsWith("appellation|")) {
+            if (!change.deleted) {
+              return AppellationAction.createAppellationSuccess({
+                appellation: change.doc,
+                source: "external",
+              });
+            } else {
+              return AppellationAction.deleteAppellationSuccess({
+                result: change,
+                source: "external",
+              });
+            }
+          }
+          // Return a no-op action for non-appellation documents
+          return AppellationAction.setStatusToLoaded();
         })
       ),
     { dispatch: true }

--- a/client/src/app/state/appellation/appellation.reducers.ts
+++ b/client/src/app/state/appellation/appellation.reducers.ts
@@ -167,8 +167,8 @@ export const appellationReducer = createReducer(
       var newEventArray = Array.from(state.eventLog);
       newAppellationMap.delete(result.id);
       newEventArray.push({
-        id: result.id ? result.id : result.doc._id,
-        rev: result.rev ? result.id : result.doc._rev,
+        id: result.id ? result.id : (result.doc ? result.doc._id : result.id),
+        rev: result.rev ? result.rev : (result.doc ? result.doc._rev : result.rev),
         action: "delete",
         timestamp: dayjs(),
       });

--- a/client/src/app/state/origine/origine.effects.ts
+++ b/client/src/app/state/origine/origine.effects.ts
@@ -54,14 +54,15 @@ export class OrigineEffects {
       this.actions$.pipe(
         ofType(OrigineAction.createOrigine),
         switchMap((action) => {
-          //        this.lastSavedWine = action.origine;
-          return of(
+          // Convert Promise to Observable using from()
+          return from(
             this.pouchService.saveDoc(
               Object.assign({}, action.origine),
               "origine"
-            )
+            ) as Promise<IResult>
           ).pipe(
             map((result: IResult) => {
+              debug("[saveOrigine$] Save result:", result);
               return OrigineAction.createOrigineSuccess({
                 origine: {
                   ...action.origine,
@@ -71,9 +72,10 @@ export class OrigineEffects {
                 source: "internal",
               });
             }),
-            catchError((error) =>
-              of(OrigineAction.createOrigineFailure({ error }))
-            )
+            catchError((error) => {
+              debug("[saveOrigine$] Save error:", error);
+              return of(OrigineAction.createOrigineFailure({ error }));
+            })
           );
         })
         /*        exhaustMap((action) =>
@@ -125,25 +127,35 @@ export class OrigineEffects {
   handleChanges$ = createEffect(
     () =>
       this.pouchService.dbChanges$.pipe(
+        // Filter to only process origine documents
         tap((change) =>
           debug(
             "[handleChanges Effect]ts: " +
               window.performance.now() +
               "\n - change : " +
-              JSON.stringify(change)
+              JSON.stringify(change) +
+              "\n - doc._id: " +
+              change.doc?._id
           )
         ),
+        // Only process changes for origine documents (those with _id starting with "origine|")
         map((change) => {
-          if (!change.deleted) {
-            return OrigineAction.createOrigineSuccess({
-              origine: change.doc,
-              source: "external",
-            });
-          } else
-            return OrigineAction.deleteOrigineSuccess({
-              result: change,
-              source: "external",
-            });
+          // Check if this is an origine document
+          if (change.doc && change.doc._id && change.doc._id.startsWith("origine|")) {
+            if (!change.deleted) {
+              return OrigineAction.createOrigineSuccess({
+                origine: change.doc,
+                source: "external",
+              });
+            } else {
+              return OrigineAction.deleteOrigineSuccess({
+                result: change,
+                source: "external",
+              });
+            }
+          }
+          // Return a no-op action for non-origine documents
+          return OrigineAction.setStatusToLoaded();
         })
       ),
     { dispatch: true }

--- a/client/src/app/state/origine/origine.reducers.ts
+++ b/client/src/app/state/origine/origine.reducers.ts
@@ -159,8 +159,8 @@ export const origineReducer = createReducer(
     var newEventArray = Array.from(state.eventLog);
     newOrigineMap.delete(result.id);
     newEventArray.push({
-      id: result.id ? result.id : result.doc._id,
-      rev: result.rev ? result.id : result.doc._rev,
+      id: result.id ? result.id : (result.doc ? result.doc._id : result.id),
+      rev: result.rev ? result.rev : (result.doc ? result.doc._rev : result.rev),
       action: "delete",
       timestamp: dayjs(),
     });

--- a/client/src/app/state/type/type.effects.ts
+++ b/client/src/app/state/type/type.effects.ts
@@ -52,11 +52,12 @@ export class TypeEffects {
       this.actions$.pipe(
         ofType(TypeAction.createType),
         switchMap((action) => {
-          //        this.lastSavedWine = action.type;
-          return of(
-            this.pouchService.saveDoc(Object.assign({}, action._type), "type")
+          // Convert Promise to Observable using from()
+          return from(
+            this.pouchService.saveDoc(Object.assign({}, action._type), "type") as Promise<IResult>
           ).pipe(
             map((result: IResult) => {
+              debug("[saveType$] Save result:", result);
               return TypeAction.createTypeSuccess({
                 _type: {
                   ...action._type,
@@ -66,7 +67,10 @@ export class TypeEffects {
                 source: "internal",
               });
             }),
-            catchError((error) => of(TypeAction.createTypeFailure({ error })))
+            catchError((error) => {
+              debug("[saveType$] Save error:", error);
+              return of(TypeAction.createTypeFailure({ error }));
+            })
           );
         })
         /*        exhaustMap((action) =>
@@ -116,25 +120,35 @@ export class TypeEffects {
   handleChanges$ = createEffect(
     () =>
       this.pouchService.dbChanges$.pipe(
+        // Filter to only process type documents
         tap((change) =>
           debug(
             "[handleChanges Effect]ts: " +
               window.performance.now() +
               "\n - change : " +
-              JSON.stringify(change)
+              JSON.stringify(change) +
+              "\n - doc._id: " +
+              change.doc?._id
           )
         ),
+        // Only process changes for type documents (those with _id starting with "type|")
         map((change) => {
-          if (!change.deleted) {
-            return TypeAction.createTypeSuccess({
-              _type: change.doc,
-              source: "external",
-            });
-          } else
-            return TypeAction.deleteTypeSuccess({
-              result: change,
-              source: "external",
-            });
+          // Check if this is a type document
+          if (change.doc && change.doc._id && change.doc._id.startsWith("type|")) {
+            if (!change.deleted) {
+              return TypeAction.createTypeSuccess({
+                _type: change.doc,
+                source: "external",
+              });
+            } else {
+              return TypeAction.deleteTypeSuccess({
+                result: change,
+                source: "external",
+              });
+            }
+          }
+          // Return a no-op action for non-type documents
+          return TypeAction.setStatusToLoaded();
         })
       ),
     { dispatch: true }

--- a/client/src/app/state/type/type.reducers.ts
+++ b/client/src/app/state/type/type.reducers.ts
@@ -159,8 +159,8 @@ export const typeReducer = createReducer(
     var newEventArray = Array.from(state.eventLog);
     newTypeMap.delete(result.id);
     newEventArray.push({
-      id: result.id ? result.id : result.doc._id,
-      rev: result.rev ? result.id : result.doc._rev,
+      id: result.id ? result.id : (result.doc ? result.doc._id : result.id),
+      rev: result.rev ? result.rev : (result.doc ? result.doc._rev : result.rev),
       action: "delete",
       timestamp: dayjs(),
     });

--- a/client/src/app/state/vin/vin.selectors.ts
+++ b/client/src/app/state/vin/vin.selectors.ts
@@ -93,7 +93,7 @@ export const getWinesByAppellation = (appellationId: string) =>
   createSelector(getAllVins, (allVinMap: Map<string, VinModel>) => {
     let filteredList = Array.from(allVinMap.values());
     return filteredList
-      .filter((item) => item.appellation._id == appellationId)
+      .filter((item) => item.appellation && item.appellation._id == appellationId)
       .sort((a, b) => (a.nom + a.annee < b.nom + b.annee ? -1 : 1));
   });
 
@@ -101,7 +101,7 @@ export const getWinesByOrigine = (origineId: string) =>
   createSelector(getAllVins, (allVinMap: Map<string, VinModel>) => {
     let filteredList = Array.from(allVinMap.values());
     return filteredList
-      .filter((item) => item.origine._id == origineId)
+      .filter((item) => item.origine && item.origine._id == origineId)
       .sort((a, b) => (a.nom + a.annee < b.nom + b.annee ? -1 : 1));
   });
 
@@ -109,7 +109,7 @@ export const getWinesByType = (typeId: string) =>
   createSelector(getAllVins, (allVinMap: Map<string, VinModel>) => {
     let filteredList = Array.from(allVinMap.values());
     return filteredList
-      .filter((item) => item.type._id == typeId)
+      .filter((item) => item.type && item.type._id == typeId)
       .sort((a, b) => (a.nom + a.annee < b.nom + b.annee ? -1 : 1));
   });
 

--- a/client/src/app/type/type.page.html
+++ b/client/src/app/type/type.page.html
@@ -8,34 +8,32 @@
 </ion-header>
 
 <ion-content class="ion-padding">
-  @if (list) {
+  @if (list()) {
     <div>
-      @if (wineTypes$ | async) {
+      @if (wineTypes().length > 0) {
         <div>
           <ion-list>
-            @for (type of wineTypes$ | async; track type) {
+            @for (type of wineTypes(); track type._id) {
               <ion-item
                 (click)="editType(type)"
                 >
                 {{ type.nom }}
-                <!-- <ion-button slot="end" fill="outline">Modify -->
                 <ion-icon
                   slot="end"
                   color="dark"
                   name="caret-forward-outline"
                 ></ion-icon>
-              <!-- </ion-button> -->
             </ion-item>
           }
         </ion-list>
       </div>
     }
-    <ion-button expand="full" (click)="editType(type)">
+    <ion-button expand="full" (click)="editType(null)">
       {{'general.add' | translate }} {{'type.type' | translate }}
     </ion-button>
   </div>
 }
-@if (!list) {
+@if (!list()) {
   <div>
     <form [formGroup]="typeForm" id="type-form4">
       <ion-item id="type-input1">
@@ -46,10 +44,10 @@
           placeholder="{{ 'type.type' | translate }}"
           formControlName="nom"
           class="ion-text-right"
-          [class.invalid]="!typeForm.controls.nom.valid && (typeForm.controls.nom.dirty || submitted)"
+          [class.invalid]="!typeForm.controls.nom.valid && (typeForm.controls.nom.dirty || submitted())"
         ></ion-input>
       </ion-item>
-      @if (!typeForm.controls.nom.valid  && (typeForm.controls.nom.dirty || submitted)) {
+      @if (!typeForm.controls.nom.valid  && (typeForm.controls.nom.dirty || submitted())) {
         <ion-item
           >
           <p class="invalid">
@@ -73,7 +71,7 @@
       >
       {{'general.save' | translate }}
     </ion-button>
-    @if (!newType) {
+    @if (!newType()) {
       <ion-button
         id="region-button5"
         ion-button

--- a/client/src/app/type/type.page.ts
+++ b/client/src/app/type/type.page.ts
@@ -1,6 +1,6 @@
 import { TranslateService } from "@ngx-translate/core";
-import { Component, OnInit, effect } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { Component, OnInit, effect, signal, computed, inject, DestroyRef } from "@angular/core";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { NavController, AlertController, IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent, IonList, IonItem, IonIcon, IonButton, IonLabel, IonInput } from "@ionic/angular/standalone";
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { TypeModel } from "../models/cellar.model";
@@ -13,13 +13,10 @@ import { ReactiveFormsModule, FormsModule } from "@angular/forms";
 import { TranslateModule } from "@ngx-translate/core";
 import { RouterModule } from "@angular/router";
 import { Store } from "@ngrx/store";
-import * as TypeSelectors from "../state/type/type.selectors";
 import * as VinSelectors from "../state/vin/vin.selectors";
-import * as AppellationSelectors from "../state/appellation/appellation.selectors";
 import * as TypeActions from "../state/type/type.actions";
-import { Observable, Subject } from "rxjs";
-import { takeUntil, tap } from "rxjs/operators";
 import { AppState } from "../state/app.state";
+import { TypeStore } from "../services/type-state.store";
 
 import { replacer } from "../util/util";
 import { addIcons } from "ionicons";
@@ -28,7 +25,7 @@ import { caretForwardOutline } from "ionicons/icons";
 const debug = Debugger("app:type");
 
 /* Restored comments from previous version:
- - We need to load the type list even if we create or modify an type because in this case we need the type list to check for doubles
+ - We need to load the type list even if we create or modify a type because in this case we need the type list to check for doubles
  - When a type is selected from the store we reset the Type state to avoid shadow UI messages coming from previous updates in other app instances
  - Handling state changes (originating from save, update or delete operations in the UI but also coming for synchronization with data from other application instances)
    - (I) internal ? => (type is saved in the application) a confirmation message is shown to the user and the app goes to the home screen
@@ -47,103 +44,89 @@ const debug = Debugger("app:type");
     imports: [CommonModule, ReactiveFormsModule, FormsModule, TranslateModule, RouterModule, IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent, IonList, IonItem, IonIcon, IonButton, IonLabel, IonInput]
 })
 export class TypePage implements OnInit {
-    public type: TypeModel = new TypeModel({
+    // ============================================
+    // DEPENDENCIES (Inject)
+    // ============================================
+    private readonly route = inject(ActivatedRoute);
+    private readonly navCtrl = inject(NavController);
+    private readonly formBuilder = inject(FormBuilder);
+    private readonly translate = inject(TranslateService);
+    private readonly alertController = inject(AlertController);
+    private readonly toastCtrl = inject(ToastController);
+    private readonly store = inject(Store<AppState>);
+    private readonly typeStore = inject(TypeStore);
+    private readonly destroyRef = inject(DestroyRef);
+
+    // ============================================
+    // COMPONENT STATE (Signals)
+    // ============================================
+    // Current type being edited - as a signal
+    readonly currentType = signal<TypeModel>(new TypeModel({
         _id: "",
         nom: "",
-    });
-    public wineTypes$!: Observable<TypeModel[]>;
-    private unsubscribe$ = new Subject<void>();
+    }));
 
-    public typeList: Array<TypeModel> = [];
-    public typesMap: Map<any, any> = new Map<any, any>();
-    public submitted: boolean = false;
+    // Get types list from TypeStore
+    readonly wineTypes = this.typeStore.typesList;
+    
+    // Get duplicate map from TypeStore
+    readonly typesMap = this.typeStore.typeMapForDuplicates;
+
+    public submitted = signal<boolean>(false);
     public typeForm!: FormGroup;
-    public list: boolean = true;
-    public newType: boolean = true;
+    public list = signal<boolean>(true);
+    public newType = signal<boolean>(true);
 
-    constructor(
-        private route: ActivatedRoute,
-        private navCtrl: NavController,
-        private formBuilder: FormBuilder,
-        private translate: TranslateService,
-        private alertController: AlertController,
-        private toastCtrl: ToastController,
-        private store: Store<AppState>
-    ) {
+    // Route parameter as signal
+    private readonly routeParams = toSignal(this.route.params);
+    readonly typeId = computed(() => this.routeParams()?.["id"] || null);
+
+    constructor() {
         addIcons({ caretForwardOutline });
-        addIcons({ caretForwardOutline });
-    }
 
-    public ngOnInit() {
-        debug("[ngOnInit]called");
-        // form initialization
-        this.typeForm = this.formBuilder.group(
-            {
-                nom: ["", Validators.required],
-            },
-            { validator: this.noDouble.bind(this) }
-        );
-        this.submitted = false;
-        this.route.snapshot.data["action"] == "list"
-            ? (this.list = true)
-            : (this.list = false);
-        // We need to load the type list even if we create or modify an type because in this case we need the type list to check for doubles
-
-        debug("[ngOnInit]calling getAllTypesArraySorted selector to set wineType$");
-        this.wineTypes$ = this.store
-            .select(TypeSelectors.getAllTypesArraySorted)
-            .pipe(
-                takeUntil(this.unsubscribe$),
-                tap((typeState) =>
-                    debug(
-                        "[ngOnInit]called getAllTypesArraySorted selector - ts " +
-                        window.performance.now() +
-                        "\ntypeState : " +
-                        JSON.stringify(typeState, replacer)
-                    )
-                )
-            );
-
-        // loading types map from state (used for double check)
-        const typesMapSignal = toSignal(
-            this.store.select(TypeSelectors.typeMapForDuplicates)
-        );
+        // Effect: Load selected type when typeId changes
         effect(() => {
-            this.typesMap = typesMapSignal() ?? new Map<any, any>();
-        });
-        // Now loading selected type from the state
-        // if id param is there, the type will be loaded, if not, we want to create a new type and the form values will remain as initialized
-        const selectedTypeSignal = toSignal(
-            this.store.select(TypeSelectors.getType(this.route.snapshot.paramMap.get("id")!))
-        );
-        effect(() => {
-            const type = selectedTypeSignal();
-            if (type) {
-                this.list = false;
-                this.type = type;
-                this.newType = false;
-                // We have selected an type
-                // reset VinState status to avoid shadow UI messages coming from previous updates in other app instances
-                this.store.dispatch(
-                    TypeActions.editType({
-                        id: type._id,
-                        rev: type._rev,
-                    })
-                );
-                this.typeForm.get("nom")!.setValue(type.nom);
-                debug("[Vin.ngOnInit]Type loaded : " + JSON.stringify(type));
+            const id = this.typeId();
+            debug("[Effect:typeId] Type ID changed:", id);
+
+            if (id) {
+                // Get type from store
+                const typeSignal = this.typeStore.getTypeById(id);
+                const type = typeSignal();
+                
+                if (type) {
+                    this.list.set(false);
+                    this.currentType.set(type);
+                    this.newType.set(false);
+                    
+                    // Reset Type state to avoid shadow UI messages
+                    this.store.dispatch(
+                        TypeActions.editType({
+                            id: type._id,
+                            rev: type._rev,
+                        })
+                    );
+                    this.typeForm.get("nom")!.setValue(type.nom);
+                    debug("[ngOnInit]Type loaded : " + JSON.stringify(type));
+                }
             } else {
-                // No wine was selected, when will register a new type
-                this.newType = true;
+                // No type selected, creating new type
+                this.newType.set(true);
+                // Reset to empty type for new creation
+                this.currentType.set(new TypeModel({
+                    _id: "",
+                    nom: "",
+                }));
                 this.store.dispatch(TypeActions.editType({ id: "", rev: "" }));
             }
-        });
+        }, { allowSignalWrites: true });
 
-        // Handling state changes (originating from save, update or delete operations in the UI but also coming for synchronization with data from other application instances)
+        // Effect: Handle state changes from NgRx (for save/delete operations)
         const typeStateSignal = toSignal(this.store.select((state: AppState) => state.types));
         effect(() => {
             const typeState = typeStateSignal();
-            if (!typeState) return; // guard against undefined
+            if (!typeState) return;
+            
             switch (typeState.status) {
                 case "saved":
                     debug(
@@ -153,16 +136,8 @@ export class TypePage implements OnInit {
                         JSON.stringify(typeState, replacer)
                     );
 
-                    // if we get an event that a wine is saved. We need to check it's id and
-                    // if the event source is internal (saved within this instance of the application) or external.
-                    // - (I) internal ? => (wine is saved in the application) a confirmation message is shown to the user and the app goes to the home scree
-                    // - (II) external ?
-                    //       - (A) event comes from the local DB resulting from the update of the wine we just saved
-                    //       - (B) event comes from the remoteDB resulting from the update of a wine ( not the one we are working on or having been working on)
-                    //       - (C) event coming from the remoteDB resulting from the update of the wine we are working on. (concurrent updata)
                     if (typeState.source == "internal") {
-                        debug("[ngInit](I) Standard wine saved");
-                        // Internal event
+                        debug("[ngInit](I) Standard type saved");
                         this.presentToast(
                             this.translate.instant("general.dataSaved"),
                             "success",
@@ -171,7 +146,6 @@ export class TypePage implements OnInit {
                         );
                         this.store.dispatch(TypeActions.setStatusToLoaded());
                     } else {
-                        // let's try to find a duplicate event in the eventLog
                         let filteredEventLog = typeState.eventLog.filter(
                             (value) =>
                                 value.id == typeState.currentType.id &&
@@ -179,8 +153,9 @@ export class TypePage implements OnInit {
                                 value.action == "create"
                         );
                         debug("[ngInit](II) FilteredEventLog : " + JSON.stringify(filteredEventLog));
+                        
                         if (filteredEventLog.length == 2) {
-                            debug("[ngInit](II.A) Duplicate state change for the same wine");
+                            debug("[ngInit](II.A) Duplicate state change for the same type");
                             this.store.dispatch(TypeActions.setStatusToLoaded());
                         } else if (
                             typeState.eventLog[typeState.eventLog.length - 1].id ==
@@ -189,10 +164,9 @@ export class TypePage implements OnInit {
                             typeState.currentType.rev &&
                             typeState.eventLog[typeState.eventLog.length - 1].action ==
                             "create" &&
-                            this.typeForm.dirty // otherwize, there is no way to make the distinction when you open a brand new editing form for a wine that has been created in another application instance
+                            this.typeForm.dirty
                         ) {
-                            // Event showing concurrent editing on the same wine that was saved somewhere else
-                            debug("[ngInit](II.C) Concurrent editing on the same wine");
+                            debug("[ngInit](II.C) Concurrent editing on the same type");
                             this.presentToast(
                                 this.translate.instant("wine.savedConcurrentlyOnAnotherInstance"),
                                 "warning",
@@ -201,10 +175,11 @@ export class TypePage implements OnInit {
                                 "Close"
                             );
                         } else {
-                            debug("[ngInit](II.B) Update of another wine");
+                            debug("[ngInit](II.B) Update of another type");
                         }
                     }
                     break;
+                    
                 case "error":
                     this.presentToast(
                         this.translate.instant("general.DBError") + " " + typeState.error,
@@ -213,18 +188,10 @@ export class TypePage implements OnInit {
                         5000
                     );
                     break;
+                    
                 case "deleted":
-                    // if we get an event that an type is saved. We need to check it's id and
-                    // if the event source is internal (saved within this instance of the application) or external.
-                    // - (I) internal ? => (type is saved in the application) a confirmation message is shown to the user and the app goes to the home scree
-                    // - (II) external ?
-                    //       - (A) event comes from the local DB resulting from the update of the wine we just saved
-                    //       - (B) event comes from the remoteDB resulting from the update of a wine ( not the one we are working on or having been working on)
-                    //       - (C) event coming from the remoteDB resulting from the update of the wine we are working on. (concurrent updata)
-                    // Delete does not suppress a doc or it's revision. It just creates a new document (with a new revision) that has the "_delete" attribute set to true
                     if (typeState.source == "internal") {
                         debug("[ngInit](I) Standard type deleted");
-                        // Internal event
                         this.presentToast(
                             this.translate.instant("type.typeDeleted"),
                             "success",
@@ -233,17 +200,16 @@ export class TypePage implements OnInit {
                         );
                         this.store.dispatch(TypeActions.setStatusToLoaded());
                     } else {
-                        // let's try to find a duplicate event in the eventLog
-                        // this should never happen for a delete
-                        if (
-                            typeState.eventLog.filter(
-                                (value) =>
-                                    value.id == typeState.currentType.id &&
-                                    value.rev >= typeState.currentType.rev &&
-                                    value.action == "delete"
-                            ).length == 2
-                        ) {
-                            debug("[ngInit](II.A) Duplicate state change for the same wine");
+                        const deleteEventsForCurrentType = typeState.eventLog.filter(
+                            (value) =>
+                                value.id == typeState.currentType.id &&
+                                value.rev >= typeState.currentType.rev &&
+                                value.action == "delete"
+                        );
+                        
+                        if (deleteEventsForCurrentType.length >= 1) {
+                            // This is the external event following our internal delete
+                            debug("[ngInit](II.A) Duplicate state change for the same type (external after internal)");
                             this.store.dispatch(TypeActions.setStatusToLoaded());
                         } else if (
                             typeState.eventLog[typeState.eventLog.length - 1].id ==
@@ -251,8 +217,7 @@ export class TypePage implements OnInit {
                             typeState.eventLog[typeState.eventLog.length - 1].action ==
                             "delete"
                         ) {
-                            // Event showing concurrent editing on the same wine that was saved somewhere else
-                            debug("[ngInit](II.C) Concurrent editing on the same wine");
+                            debug("[ngInit](II.C) Concurrent editing on the same type");
                             this.presentToast(
                                 this.translate.instant("type.deletedConcurrentlyOnAnotherInstance"),
                                 "warning",
@@ -261,51 +226,64 @@ export class TypePage implements OnInit {
                                 "Close"
                             );
                         } else {
-                            debug("[ngInit](II.B) Delete of another wine");
+                            debug("[ngInit](II.B) Delete of another type");
                         }
                     }
                     break;
             }
-        });
+        }, { allowSignalWrites: true });
     }
-    public ngOnDestroy() {
-        debug("[Type.ngOnDestroy]called");
-        // Unscubribe all observers
-        this.unsubscribe$.next();
-        this.unsubscribe$.complete();
+
+    public ngOnInit() {
+        debug("[ngOnInit]called");
+        
+        // form initialization
+        this.typeForm = this.formBuilder.group(
+            {
+                nom: ["", Validators.required],
+            },
+            { validator: this.noDouble.bind(this) }
+        );
+        this.submitted.set(false);
+        
+        // Set list mode based on route data
+        this.route.snapshot.data["action"] == "list"
+            ? this.list.set(true)
+            : this.list.set(false);
     }
 
     private noDouble(group: FormGroup) {
         debug("[noDouble] called");
         if (!group.controls["nom"] || !group.controls["nom"].dirty) return null;
-        if (this.typesMap && this.typesMap.has(group.value.nom)) {
+        
+        const typesMap = this.typesMap();
+        if (typesMap && typesMap.has(group.value.nom)) {
             debug("[noDouble]double detected");
             return { double: true };
         } else return null;
     }
 
-    public editType(type) {
-        if (type._id) this.navCtrl.navigateForward(["/type", type._id]);
+    public editType(type: TypeModel | null) {
+        if (type && type._id) this.navCtrl.navigateForward(["/type", type._id]);
         else this.navCtrl.navigateForward(["/type"]);
     }
 
     public saveType() {
         debug("[saveType]entering");
-        this.submitted = true;
+        this.submitted.set(true);
+        
         if (this.typeForm.valid) {
-            // validation succeeded
-            debug("[TypeVin]Type valid");
-            // when the vin has been loaded from the store, it is immutable, we need to deep copy it before being able to update its properties
-            let mutableType = JSON.parse(JSON.stringify(this.type));
-            // now combine the loaded wine data with the new form data
-            this.type = {
-                ...mutableType,
+            debug("[saveType]Type valid");
+            const currentType = this.currentType();
+            const updatedType = {
+                ...currentType,
                 ...this.typeForm.value,
             };
+            this.currentType.set(updatedType);
 
-            this.store.dispatch(TypeActions.createType({ _type: this.type }));
+            this.store.dispatch(TypeActions.createType({ _type: updatedType }));
         } else {
-            debug("[Vin - saveVin]vin invalid");
+            debug("[saveType]type invalid");
             this.presentToast(
                 this.translate.instant("general.invalidData"),
                 "error",
@@ -315,15 +293,16 @@ export class TypePage implements OnInit {
     }
 
     public deleteType() {
-        // Before deleting an type, we need to check if this type is not used for any of the wines.
-        // If it is used, it can't be deleted.
+        // Check if type is used by any wines
+        const currentType = this.currentType();
         let used = false;
         this.store
-            .select(VinSelectors.getWinesByType(this.type._id))
-            .pipe(takeUntil(this.unsubscribe$))
+            .select(VinSelectors.getWinesByType(currentType._id))
+            .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe((wineListForType) =>
                 wineListForType.length > 0 ? (used = true) : (used = false)
             );
+            
         if (!used) {
             this.alertController
                 .create({
@@ -338,7 +317,7 @@ export class TypePage implements OnInit {
                             handler: () => {
                                 this.store.dispatch(
                                     TypeActions.deleteType({
-                                        _type: this.type,
+                                        _type: currentType,
                                     })
                                 );
                             },
@@ -400,3 +379,5 @@ export class TypePage implements OnInit {
         }
     }
 }
+
+// Made with Bob


### PR DESCRIPTION
(feat: Complete signal migration for Type, Appellation, and Region components)

- Migrated Type, Appellation, and Region components to @ngrx/signals SignalStore
- Fixed critical NgRx effects bug: changed of() to from() for Promise handling
- Added document type filtering in handleChanges$ effects to prevent cross-contamination
- Fixed NG0602 error by moving toSignal() out of computed() contexts
- Added defensive null checks in all wine selectors
- Fixed delete operation crashes with proper result.doc handling in reducers
- Converted mutable properties to signals to fix readonly property errors
- Fixed create operations by resetting signals to empty models
- Fixed list view display by removing incorrect list.set(false) override
- Fixed add button crashes with proper null parameter handling
- Fixed false concurrent delete warnings with improved duplicate detection logic
- Optimized performance by fixing track expressions in @for loops (NG0956)
- All CRUD operations verified and working correctly

All components are now production-ready with improved performance and type safety.